### PR TITLE
Add Flask web endpoint for Kubernetes operations

### DIFF
--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -46,6 +46,8 @@ This document provides instructions on how to set up the environment and test th
 
 ## 3. Setup and Run the Flask Application
 
+**Important:** All commands in this section should be executed from the root directory of the project (the one containing the `k8s_client` directory and `requirements.txt`).
+
 1.  **Clone the repository (if you haven't already):**
     ```bash
     # git clone <repository-url>
@@ -62,13 +64,18 @@ This document provides instructions on how to set up the environment and test th
     ```
 
 3.  **Run the Flask application:**
-    From the root of the project directory:
     ```bash
-    python k8s_client/web_app.py
+    # From the project root directory:
+    python -m k8s_client.web_app
     ```
-    Alternatively, you can use the `flask` command (ensure you are in the directory containing `k8s_client` or set `FLASK_APP`):
     ```bash
-    # FLASK_APP=k8s_client.web_app flask run --host=0.0.0.0 --port=5000
+    # Alternatively, from the project root directory, you can use the `flask` command:
+    # Ensure FLASK_APP points to the web_app.py file relative to your current directory.
+    FLASK_APP=k8s_client/web_app.py flask run --host=0.0.0.0 --port=5000
+    ```
+    ```bash
+    # As another alternative, from the project root directory:
+    python k8s_client/web_app.py
     ```
     The application will typically start on `http://0.0.0.0:5000/`.
 

--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -1,0 +1,137 @@
+# Testing Instructions for the Kubernetes Flask Web App
+
+This document provides instructions on how to set up the environment and test the Flask web application endpoint for managing Kubernetes deployments.
+
+## 1. Prerequisites
+
+*   **Minikube:** Install Minikube by following the official instructions for your operating system: [https://minikube.sigs.k8s.io/docs/start/](https://minikube.sigs.k8s.io/docs/start/)
+*   **kubectl:** Install kubectl, the Kubernetes command-line tool: [https://kubernetes.io/docs/tasks/tools/install-kubectl/](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+*   **Python:** Ensure Python (3.8+) is installed.
+*   **Git:** Ensure Git is installed to clone the repository.
+
+## 2. Setup Kubernetes Cluster and Deploy Application
+
+1.  **Start Minikube:**
+    ```bash
+    minikube start
+    ```
+    *(Wait for the cluster to be ready. This might take a few minutes.)*
+
+2.  **Set kubectl context to Minikube (usually done automatically by `minikube start`):**
+    ```bash
+    kubectl config use-context minikube
+    ```
+
+3.  **Deploy the 'hello-minikube' application:**
+    This is the application we will test against.
+    ```bash
+    kubectl create deployment hello-minikube --image=kicbase/echo-server:1.0
+    ```
+
+4.  **Expose the 'hello-minikube' deployment (Optional, but good for verification):**
+    ```bash
+    kubectl expose deployment hello-minikube --type=NodePort --port=8080
+    ```
+    You can get the URL to access it via:
+    ```bash
+    minikube service hello-minikube --url
+    ```
+
+5.  **Verify deployment:**
+    Check if the `hello-minikube` pods are running:
+    ```bash
+    kubectl get pods
+    ```
+    You should see pods with names like `hello-minikube-<some-hash>-<some-id>`.
+
+## 3. Setup and Run the Flask Application
+
+1.  **Clone the repository (if you haven't already):**
+    ```bash
+    # git clone <repository-url>
+    # cd <repository-directory>
+    ```
+
+2.  **Install dependencies:**
+    Navigate to the root of the project directory (where `requirements.txt` is located).
+    It's recommended to use a virtual environment:
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows use `venv\Scripts\activate`
+    pip install -r requirements.txt
+    ```
+
+3.  **Run the Flask application:**
+    From the root of the project directory:
+    ```bash
+    python k8s_client/web_app.py
+    ```
+    Alternatively, you can use the `flask` command (ensure you are in the directory containing `k8s_client` or set `FLASK_APP`):
+    ```bash
+    # FLASK_APP=k8s_client.web_app flask run --host=0.0.0.0 --port=5000
+    ```
+    The application will typically start on `http://0.0.0.0:5000/`.
+
+## 4. Test the API Endpoints
+
+Use a tool like `curl` or Postman to send requests to the Flask application. Replace `hello-minikube` with your target deployment if different. The default namespace is assumed.
+
+**Target Deployment:** `hello-minikube`
+
+**Endpoints:**
+
+*   **List Pods:**
+    ```bash
+    curl http://localhost:5000/api/deployment/hello-minikube/list_pods
+    ```
+    *(Expected: JSON response indicating success. Pod details will be printed in the Flask app's console output.)*
+
+*   **Pause Deployment:**
+    ```bash
+    curl -X POST http://localhost:5000/api/deployment/hello-minikube/pause_deployment
+    ```
+    *(Expected: JSON response indicating success. Verify by checking deployment status with `kubectl get deployment hello-minikube` - replicas should go to 0 if observed immediately, or new rollouts will be paused.)*
+    To see the effect, you might try scaling after pausing:
+    ```bash
+    kubectl scale deployment hello-minikube --replicas=3 # This change will be pending
+    kubectl get pods # You might not see new pods immediately
+    ```
+
+*   **Resume Deployment:**
+    ```bash
+    curl -X POST http://localhost:5000/api/deployment/hello-minikube/resume_deployment
+    ```
+    *(Expected: JSON response indicating success. If you paused and scaled, the new replicas should now start creating.)*
+    ```bash
+    kubectl get pods # You should see new pods if you scaled up while paused
+    ```
+
+*   **Restart Deployment:**
+    ```bash
+    curl -X POST http://localhost:5000/api/deployment/hello-minikube/restart_deployment
+    ```
+    *(Expected: JSON response indicating success. Pods for `hello-minikube` will be terminated and new ones created. Check with `kubectl get pods`.)*
+
+*   **Invalid Command:**
+    ```bash
+    curl http://localhost:5000/api/deployment/hello-minikube/invalid_command
+    ```
+    *(Expected: JSON response with an error message and a 400 status code.)*
+
+## 5. Cleanup
+
+1.  **Delete the deployment:**
+    ```bash
+    kubectl delete deployment hello-minikube
+    kubectl delete service hello-minikube
+    ```
+
+2.  **Stop Minikube:**
+    ```bash
+    minikube stop
+    ```
+
+3.  **Deactivate virtual environment (if used):**
+    ```bash
+    deactivate
+    ```

--- a/k8s_client/web_app.py
+++ b/k8s_client/web_app.py
@@ -25,5 +25,13 @@ def manage_deployment(deployment_name: str, command: str):
         return jsonify({"status": "error", "message": str(e)}), 500
 
 if __name__ == '__main__':
+    import os
+    import sys
+    # Add the project root to sys.path to allow direct execution of web_app.py
+    # and resolve imports like 'from k8s_client.controller...'
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
     # Note: For development only. For production, use a WSGI server.
     app.run(debug=True, host='0.0.0.0', port=5000)

--- a/k8s_client/web_app.py
+++ b/k8s_client/web_app.py
@@ -1,0 +1,29 @@
+from flask import Flask, request, jsonify
+from k8s_client.controller.kubernetes_controller import KubernetesController
+
+app = Flask(__name__)
+
+@app.route('/api/deployment/<string:deployment_name>/<string:command>', methods=['GET', 'POST'])
+def manage_deployment(deployment_name: str, command: str):
+    controller = KubernetesController()
+    try:
+        if command == "list_pods":
+            controller.list_pods_with_logs(namespace_filter="default")
+            return jsonify({"status": "success", "command": "list_pods", "message": "Pods listed. Check application logs for details."}), 200
+        elif command == "pause_deployment":
+            controller.pause_deployment(namespace="default", deployment_name=deployment_name)
+            return jsonify({"status": "success", "command": "pause_deployment", "deployment_name": deployment_name}), 200
+        elif command == "restart_deployment":
+            controller.restart_deployment(namespace="default", deployment_name=deployment_name)
+            return jsonify({"status": "success", "command": "restart_deployment", "deployment_name": deployment_name}), 200
+        elif command == "resume_deployment":
+            controller.resume_deployment(namespace="default", deployment_name=deployment_name)
+            return jsonify({"status": "success", "command": "resume_deployment", "deployment_name": deployment_name}), 200
+        else:
+            return jsonify({"status": "error", "message": "Invalid command"}), 400
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+if __name__ == '__main__':
+    # Note: For development only. For production, use a WSGI server.
+    app.run(debug=True, host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 kubernetes=32.0.1
+Flask>=2.0.0


### PR DESCRIPTION
This commit introduces a Flask web application that provides an API endpoint to manage Kubernetes deployments.

The endpoint `/api/deployment/<deployment_name>/<command>` allows you to issue the following commands to a specified deployment in the default namespace:
- list_pods: Lists pods (output to Flask console).
- pause_deployment: Pauses the deployment.
- restart_deployment: Restarts the deployment.
- resume_deployment: Resumes a paused deployment.

The existing KubernetesController is leveraged to perform these actions. Flask has been added to requirements.txt.

Testing instructions are provided in TESTING_INSTRUCTIONS.md, detailing how to set up Minikube, deploy the 'hello-minikube' sample application, and test the new API endpoints.